### PR TITLE
feat(component-overview): reuse component metadata

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -556,6 +556,7 @@ export default defineConfig({
             { text: 'Component Overview', link: '/components/' },
             { text: 'Alert', link: '/components/alert/' },
             { text: 'Attention', link: '/components/attention/' },
+            { text: 'Avatar', link: '/components/avatar/' },
             { text: 'Badge', link: '/components/badge/' },
             { text: 'Box', link: '/components/box/' },
             { text: 'Breadcrumbs', link: '/components/breadcrumbs/' },

--- a/docs/components/alert/data.json
+++ b/docs/components/alert/data.json
@@ -1,0 +1,34 @@
+{
+  "title": "Alert",
+  "description": "Alert is an inline component used for displaying different types of messages.",
+  "image": {
+    "src": "/warp-portal-poc/css/la01.jpg",
+    "alt": "Alert component"
+  },
+  "frameworks": [
+    {
+      "name": "React",
+      "status": "released"
+    },
+    {
+      "name": "Vue",
+      "status": "released"
+    },
+    {
+      "name": "Elements",
+      "status": "released"
+    },
+    {
+      "name": "Android",
+      "status": "released"
+    },
+    {
+      "name": "iOS",
+      "status": "released"
+    },
+    {
+      "name": "Figma"
+    }
+  ],
+  "category": "Feedback"
+}

--- a/docs/components/alert/index.md
+++ b/docs/components/alert/index.md
@@ -4,13 +4,15 @@
   import React from './react.md';
   import Android from './android.md';
   import iOS from './ios.md';
+  import data from './data.json';
+  import { mapFrameworkStatuses } from '../utils.js';
 </script>
 
 # Alert
 
-Alert is an inline component used for displaying different types of messages.
+{{ data.description }}
 
-<components-status react='released' vue='released' elements='released' android='released' ios='released' />
+<components-status v-bind="mapFrameworkStatuses(data.frameworks)" />
 
 ## Example
 

--- a/docs/components/avatar/data.json
+++ b/docs/components/avatar/data.json
@@ -1,0 +1,14 @@
+{
+  "title": "Avatar",
+  "description": "Avatars use images, icons or text to visually represent people or entities.",
+  "image": {
+    "src": "/warp-portal-poc/css/la02.jpg",
+    "alt": "Avatar component"
+  },
+  "frameworks": [
+    {
+      "name": "Figma"
+    }
+  ],
+  "category": "Layout"
+}

--- a/docs/components/avatar/index.md
+++ b/docs/components/avatar/index.md
@@ -1,0 +1,11 @@
+<script setup>
+  import data from './data.json';
+  import { mapFrameworkStatuses } from '../utils.js';
+</script>
+
+# Avatar
+
+{{ data.description }}
+
+<components-status v-bind="mapFrameworkStatuses(data.frameworks)" />
+

--- a/docs/components/badge/data.json
+++ b/docs/components/badge/data.json
@@ -1,0 +1,34 @@
+{
+  "title": "Badge",
+  "description": "Badge is used for showing a small amount of non-interactive color-categorized metadata, like a status or count.",
+  "image": {
+    "src": "/warp-portal-poc/css/la03.jpg",
+    "alt": "Badge component"
+  },
+  "frameworks": [
+    {
+      "name": "React",
+      "status": "released"
+    },
+    {
+      "name": "Vue",
+      "status": "released"
+    },
+    {
+      "name": "Elements",
+      "status": "released"
+    },
+    {
+      "name": "Android",
+      "status": "released"
+    },
+    {
+      "name": "iOS",
+      "status": "released"
+    },
+    {
+      "name": "Figma"
+    }
+  ],
+  "category": "Layout"
+}

--- a/docs/components/badge/index.md
+++ b/docs/components/badge/index.md
@@ -4,13 +4,15 @@
   import React from './react.md';
   import Android from './android.md';
   import iOS from './ios.md';
+  import data from './data.json';
+  import { mapFrameworkStatuses } from '../utils.js';
 </script>
 
 # Badge
 
-Badge is used for showing a small amount of non-interactive color-categorized metadata, like a status or count.
+{{ data.description }}
 
-<components-status react='released' vue='released' elements='released' android='released' ios='released' />
+<components-status v-bind="mapFrameworkStatuses(data.frameworks)" />
 
 ## Example
 

--- a/docs/components/box/data.json
+++ b/docs/components/box/data.json
@@ -1,0 +1,34 @@
+{
+  "title": "Box",
+  "description": "Box is a layout component used for separating content areas on a page.",
+  "image": {
+    "src": "/warp-portal-poc/css/la04.jpg",
+    "alt": "Box component"
+  },
+  "frameworks": [
+    {
+      "name": "React",
+      "status": "released"
+    },
+    {
+      "name": "Vue",
+      "status": "released"
+    },
+    {
+      "name": "Elements",
+      "status": "released"
+    },
+    {
+      "name": "Android",
+      "status": "released"
+    },
+    {
+      "name": "iOS",
+      "status": "released"
+    },
+    {
+      "name": "Figma"
+    }
+  ],
+  "category": "Actions"
+}

--- a/docs/components/box/index.md
+++ b/docs/components/box/index.md
@@ -4,13 +4,15 @@
   import React from './react.md';
   import Android from './android.md';
   import iOS from './ios.md';
+  import data from './data.json';
+  import { mapFrameworkStatuses } from '../utils.js';
 </script>
 
 # Box
 
-Box is a layout component used for separating content areas on a page.
+{{ data.description }}
 
-<components-status react='released' vue='released' elements='released' android='released' ios='released'/>
+<components-status v-bind="mapFrameworkStatuses(data.frameworks)" />
 
 ## Example
 

--- a/docs/components/breadcrumbs/data.json
+++ b/docs/components/breadcrumbs/data.json
@@ -1,0 +1,26 @@
+{
+  "title": "Breadcrumbs",
+  "description": "Breadcrumbs show the navigation structure for the current location.",
+  "image": {
+    "src": "/warp-portal-poc/css/la05.jpg",
+    "alt": "Breadcrumbs component"
+  },
+  "frameworks": [
+    {
+      "name": "React",
+      "status": "released"
+    },
+    {
+      "name": "Vue",
+      "status": "released"
+    },
+    {
+      "name": "Elements",
+      "status": "released"
+    },
+    {
+      "name": "Figma"
+    }
+  ],
+  "category": "Layout"
+}

--- a/docs/components/breadcrumbs/index.md
+++ b/docs/components/breadcrumbs/index.md
@@ -2,13 +2,15 @@
   import Vue from './vue.md';
   import Elements from './elements.md';
   import React from './react.md';
+  import data from './data.json';
+  import { mapFrameworkStatuses } from '../utils.js';
 </script>
 
 # Breadcrumbs
 
-Breadcrumbs show the navigation structure for the current location.
+{{ data.description }}
 
-<components-status react='released' vue='released' elements='released' />
+<components-status v-bind="mapFrameworkStatuses(data.frameworks)" />
 
 ## Example
 

--- a/docs/components/buttons/data.json
+++ b/docs/components/buttons/data.json
@@ -1,0 +1,34 @@
+{
+  "title": "Button",
+  "description": "Buttons are used to perform actions, with different visuals for different needs.",
+  "image": {
+    "src": "/warp-portal-poc/css/la06.jpg",
+    "alt": "Button component"
+  },
+  "frameworks": [
+    {
+      "name": "React",
+      "status": "released"
+    },
+    {
+      "name": "Vue",
+      "status": "released"
+    },
+    {
+      "name": "Elements",
+      "status": "released"
+    },
+    {
+      "name": "Android",
+      "status": "released"
+    },
+    {
+      "name": "iOS",
+      "status": "released"
+    },
+    {
+      "name": "Figma"
+    }
+  ],
+  "category": "Actions"
+}

--- a/docs/components/buttons/index.md
+++ b/docs/components/buttons/index.md
@@ -4,13 +4,15 @@
   import React from './react.md';
   import Android from './android.md';
   import iOS from './ios.md';
+  import data from './data.json';
+  import { mapFrameworkStatuses } from '../utils.js';
 </script>
 
 # Button
 
-Buttons are used to perform actions, with different visuals for different needs.
+{{ data.description }}
 
-<components-status react='released' vue='released' elements='released' android='released' ios='released' />
+<components-status v-bind="mapFrameworkStatuses(data.frameworks)" />
 
 ## Example
 

--- a/docs/components/card/data.json
+++ b/docs/components/card/data.json
@@ -1,0 +1,26 @@
+{
+  "title": "Card",
+  "description": "Card is a layout component used for a traditional card look and feel.",
+  "image": {
+    "src": "/warp-portal-poc/css/la07.jpg",
+    "alt": "Card component"
+  },
+  "frameworks": [
+    {
+      "name": "React",
+      "status": "released"
+    },
+    {
+      "name": "Vue",
+      "status": "released"
+    },
+    {
+      "name": "Elements",
+      "status": "released"
+    },
+    {
+      "name": "Figma"
+    }
+  ],
+  "category": "Layout"
+}

--- a/docs/components/card/index.md
+++ b/docs/components/card/index.md
@@ -2,13 +2,15 @@
   import Vue from './vue.md';
   import React from './react.md';
   import Elements from './elements.md';
+  import data from './data.json';
+  import { mapFrameworkStatuses } from '../utils.js';
 </script>
 
 # Card
 
-Card is a layout component used for a traditional card look and feel.
+{{ data.description }}
 
-<components-status react='released' vue='released' elements='released' />
+<components-status v-bind="mapFrameworkStatuses(data.frameworks)" />
 
 ## Examples
 

--- a/docs/components/checkbox/data.json
+++ b/docs/components/checkbox/data.json
@@ -1,0 +1,26 @@
+{
+  "title": "Checkbox",
+  "description": "Checkboxes allow users to select multiple items from a list of individual items, or to mark one individual item as selected.",
+  "image": {
+    "src": "/warp-portal-poc/css/la08.jpg",
+    "alt": "Checkbox component"
+  },
+  "frameworks": [
+    {
+      "name": "React",
+      "status": "released"
+    },
+    {
+      "name": "Vue",
+      "status": "released"
+    },
+    {
+      "name": "Android",
+      "status": "released"
+    },
+    {
+      "name": "Figma"
+    }
+  ],
+  "category": "Forms"
+}

--- a/docs/components/checkbox/index.md
+++ b/docs/components/checkbox/index.md
@@ -2,13 +2,15 @@
   import Vue from './vue.md';
   import React from './react.md';
   import Android from './android.md';
+  import data from './data.json';
+  import { mapFrameworkStatuses } from '../utils.js';
 </script>
 
 # Checkbox
 
-Checkboxes allow users to select multiple items from a list of individual items, or to mark one individual item as selected.
+{{ data.description }}
 
-<components-status react='released' vue='released' android='released' />
+<components-status v-bind="mapFrameworkStatuses(data.frameworks)" />
 
 ## Example
 

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -1,27 +1,24 @@
+<script setup>
+const components = import.meta.glob('./*/data.json', { eager: true })
+const baseUrl = import.meta.env.BASE_URL
+
+const componentData = Object.keys(components).map(path => {
+ return ({
+  ...components[path].default, // component data from JSON
+  href: `${baseUrl}components/${path.replace('/data.json', '')}`
+})});
+
+</script>
+
 # Overview
 All WARP components for Figma, React, Vue, Elements, iOS, and Android.
 
 [Filters]
 
 <cards>
-  <card imgurl="/warp-portal-poc/css/la01.jpg" imgalt="Awsome AI generated stuff">
-    <h3 class="h4 m-0! mb-8! text-m!">Alert</h3>
-    <p class="m-0! text-s">Alerts show high-signal messages meant to be noticed and prompting users to take action.</p>
-  </card>
-  <card imgurl="/warp-portal-poc/css/la02.jpg" imgalt="Awsome AI generated stuff">
-    <h3 class="h4 m-0! mb-8! text-m!">Avatar</h3>
-    <p class="m-0! text-s">Avatars use images, icons or text to visually represent people or entities.</p>
-  </card>
-  <card imgurl="/warp-portal-poc/css/la03.jpg" imgalt="Awsome AI generated stuff">
-    <h3 class="h4 m-0! mb-8! text-m!">Badge</h3>
-    <p class="m-0! text-s">Badges are for showing a small amount of colour-categorised metadata.</p>
-  </card>
-  <card imgurl="/warp-portal-poc/css/la04.jpg" imgalt="Awsome AI generated stuff">
-    <h3 class="h4 m-0! mb-8! text-m!">Box</h3>
-    <p class="m-0! text-s">Alerts show high-signal messages meant to be noticed and prompting users to take action.</p>
-  </card>
-    <card imgurl="/warp-portal-poc/css/la05.jpg" imgalt="Awsome AI generated stuff">
-    <h3 class="h4 m-0! mb-8! text-m!">Breadcrumbs</h3>
-    <p class="m-0! text-s">Alerts show high-signal messages meant to be noticed and prompting users to take action.</p>
+  <card v-for="component in componentData" :key="component.title"
+    :imgurl="component.image.src" :imgalt="component.image.alt">
+    <h3 class="h4 m-0! mb-8! text-m!">{{ component.title }}</h3>
+    <p class="m-0! text-s">{{ component.description }}</p>
   </card>
 </cards>

--- a/docs/components/radio/data.json
+++ b/docs/components/radio/data.json
@@ -1,0 +1,21 @@
+{
+  "title": "Radio",
+  "description": "Radios allow users to select a single option from a list of mutually exclusive options. All possible options are exposed up front for users to compare.",
+  "image": {
+    "src": "/warp-portal-poc/css/la09.jpg",
+    "alt": "Radio component"
+  },  "frameworks": [
+    {
+      "name": "React",
+      "status": "released"
+    },
+    {
+      "name": "Vue",
+      "status": "released"
+    },
+    {
+      "name": "Figma"
+    }
+  ],
+  "category": "Forms"
+}

--- a/docs/components/radio/index.md
+++ b/docs/components/radio/index.md
@@ -1,13 +1,15 @@
 <script setup>
   import Vue from './vue.md';
   import React from './react.md';
+  import data from './data.json';
+  import { mapFrameworkStatuses } from '../utils.js';
 </script>
 
 # Radio
 
-Radios allow users to select a single option from a list of mutually exclusive options. All possible options are exposed up front for users to compare.
+{{ data.description }}
 
-<components-status react='released' vue='released' />
+<components-status v-bind="mapFrameworkStatuses(data.frameworks)" />
 
 ## Example
 

--- a/docs/components/utils.js
+++ b/docs/components/utils.js
@@ -1,0 +1,6 @@
+export const mapFrameworkStatuses = (data) => data.reduce((acc, framework) => {
+  if (framework.status) {
+    acc[framework.name.toLowerCase()] = framework.status
+  }
+  return acc;
+}, {});


### PR DESCRIPTION
## Description
This PR is an attempt to share repeated component data within the Components section. 

## Changes included
- added basic data about a few components in json format
- used this data to present description and framework status in respective component pages (added a helper function to util.js to map json data to ComponentStatuses props)
- used the same set of data to dynamically display a grid of component cards in the Component Overview page
- also added an Avatar component as an example of a Figma-only component

The data also contains a dynamically set url under `component.href` property, which can be used in the overview cards to navigate to correct component page.