### PR TITLE
change card structure to allow for accessability tweaks

### DIFF
--- a/docs/.vitepress/Card.vue
+++ b/docs/.vitepress/Card.vue
@@ -11,29 +11,17 @@
 // </cards>
 -->
 
-<script setup>
-const props = defineProps({
-  imgurl: String,
-  imgalt: String,
-});
-</script>
-
 <template>
-  <article class="card-wrapper rounded-4 shadow-s overflow-hidden">
-    <div v-if="imgurl" class="flex items-center justify-center gap-8 overflow-hidden img-bg" style="aspect-ratio: 4 / 3">
-      <img :src="imgurl" :alt="imgalt">
-    </div>
-    <div class="do-caption p-16">
-      <slot></slot>
-    </div>
+  <article class="docs-card rounded-4 shadow-s focus-within:shadow-m hover:shadow-m overflow-hidden relative">
+    <slot></slot>
   </article>
 </template>
 
-<style lang="scss">
-.card-wrapper {
-  .img-bg {
-    background-color: #F9F9FA;
-  }
+<style scoped lang="scss">
+
+.docs-card:focus-within{
+  //border: 1px solid red;
 }
+
 </style>
 

--- a/docs/.vitepress/Card.vue
+++ b/docs/.vitepress/Card.vue
@@ -16,12 +16,3 @@
     <slot></slot>
   </article>
 </template>
-
-<style scoped lang="scss">
-
-.docs-card:focus-within{
-  //border: 1px solid red;
-}
-
-</style>
-

--- a/docs/.vitepress/Cards.vue
+++ b/docs/.vitepress/Cards.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="grid grid-cols-1 sm:grid-cols-3 gap-24 ">
+  <section class="gap-24 ">
     <slot></slot>
   </section>
 </template>

--- a/docs/components/alert/data.json
+++ b/docs/components/alert/data.json
@@ -1,5 +1,6 @@
 {
   "title": "Alert",
+  "mainurl": "/warp-portal-poc/components/alert/",
   "description": "Alert is an inline component used for displaying different types of messages.",
   "image": {
     "src": "/warp-portal-poc/css/la01.jpg",

--- a/docs/components/alert/data.json
+++ b/docs/components/alert/data.json
@@ -1,6 +1,5 @@
 {
   "title": "Alert",
-  "mainurl": "/warp-portal-poc/components/alert/",
   "description": "Alert is an inline component used for displaying different types of messages.",
   "image": {
     "src": "/warp-portal-poc/css/la01.jpg",

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -18,7 +18,7 @@ All WARP components for Figma, React, Vue, Elements, iOS, and Android.
 <cards class="grid grid-cols-1 sm:grid-cols-3">
   <card v-for="component in componentData" :key="component.title" class="flex flex-col">
     <h3 class="h4 text-m! static! mt-16! mx-16!">
-      <a :href="component.mainurl" class="block before:content-empty before:absolute before:top-0 before:right-0 before:bottom-0 before:left-0 focus:outline-0">{{ component.title }}</a>
+      <a :href="component.href" class="block before:content-empty before:absolute before:top-0 before:right-0 before:bottom-0 before:left-0 focus:outline-0">{{ component.title }}</a>
     </h3>
     <img class="order-first" :src="component.image.src" :alt="component.image.alt"/>
     <p class="m-16! text-s">{{ component.description }}</p>

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -15,10 +15,12 @@ All WARP components for Figma, React, Vue, Elements, iOS, and Android.
 
 [Filters]
 
-<cards>
-  <card v-for="component in componentData" :key="component.title"
-    :imgurl="component.image.src" :imgalt="component.image.alt">
-    <h3 class="h4 m-0! mb-8! text-m!">{{ component.title }}</h3>
-    <p class="m-0! text-s">{{ component.description }}</p>
+<cards class="grid grid-cols-1 sm:grid-cols-3">
+  <card v-for="component in componentData" :key="component.title" class="flex flex-col">
+    <h3 class="h4 text-m! static! mt-16! mx-16!">
+      <a :href="component.mainurl" class="block before:content-empty before:absolute before:top-0 before:right-0 before:bottom-0 before:left-0 focus:outline-0">{{ component.title }}</a>
+    </h3>
+    <img class="order-first" :src="component.image.src" :alt="component.image.alt"/>
+    <p class="m-16! text-s">{{ component.description }}</p>
   </card>
 </cards>


### PR DESCRIPTION
To make te accessability stuff and also styling options viable I saw 2 solves
1. move  the content inside the component itself, looked to rigid and less likely we could reuse it for other things. 
2. (Chosen solve )move the content bit outside of the card, means more styling in the actual use of the component but I think that is fine since we are the only consumer of the thing. Allows alot of flexibility. 

This thing is styled with unoclasses for now. 

 