### PR TITLE
Imageblock

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -4,6 +4,8 @@ import { presetWarp } from '@warp-ds/uno';
 import uno from 'unocss/vite';
 import { classes as componentClasses } from '@warp-ds/css/component-classes/classes';
 import { supported as supportedClasses } from '../supported.js';
+import markdownItContainer from 'markdown-it-container';
+
 
 const base = '/warp-portal-poc';
 
@@ -107,6 +109,17 @@ export default defineConfig({
       light: "github-light",
       dark: "github-dark",
     },
+    config: (md) => {
+      md.use(markdownItContainer, 'image-block', {
+        render: (tokens, idx) => {
+          if (tokens[idx].nesting === 1) {
+            return '<div class="styled-image-block">';
+          } else {
+            return '</div>';
+          }
+        }
+      });
+    }
   },
   vue: {
     template: {

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -108,3 +108,23 @@ html.dark body {
 {
   color: var(--vp-c-brand-2);
 }
+
+.styled-image-block {
+    background-color: #f5f5f5; /* Light grey background */
+    padding: 16px;
+    margin: 16px 0;
+    border-radius: 8px; /* Optional: rounded corners */
+    width: 100%; /* Full width of parent */
+    position: relative; /* For absolute positioning of image */
+    overflow: hidden; /* To hide any overflow of the image */
+    aspect-ratio: 4 / 3; /* Maintain a 4:3 aspect ratio */
+    display: flex;
+    align-items: center; /* Center image vertically */
+    justify-content: center; /* Center image horizontally */
+}
+
+.styled-image-block img {
+  max-width: 100%; /* Ensure the image scales to fit within the container */
+  height: auto; /* Maintain image aspect ratio */
+  object-fit: cover; /* Cover the container, preserving aspect ratio */
+}

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -113,7 +113,7 @@ html.dark body {
     background-color: #f5f5f5; /* Light grey background */
     padding: 16px;
     margin: 16px 0;
-    border-radius: 8px; /* Optional: rounded corners */
+    border-radius: 8px;
     width: 100%; /* Full width of parent */
     position: relative; /* For absolute positioning of image */
     overflow: hidden; /* To hide any overflow of the image */

--- a/docs/foundations/index.md
+++ b/docs/foundations/index.md
@@ -4,6 +4,13 @@
 
 ## Warp Ipsum
 
+<image imageurl="/warp-portal-poc/css/matter.jpg" imgalt="is noice" imgcaption="Beautiful image" aspectratio="4/3" />
+
+
+::: image-block
+![Beautiful image](/css/matter.jpg)
+:::
+
 Nulla portalis magnus quantum fluxus, et interdimensional nexus stabilis. Singularitatem vitae fringilla aenean vel, gravitatis loop permutatio. Non-stop phasing, omni-directional communication relay cursus ut nisl. Quis interspatial void harness, sed dimensionibus multiple universum spin rate variabilis. Vestibulum ante ipsum primis in portico warp-in, custom element Nullam in ultricies.
 
 Hyper-speed oscillation elementum, dilatation tempus orci tempor at. In graviton torsion ligula, nec dimensional rift congue in. Nullam magna torque stabilizer tempor nec. Exponential wormhole implosio risus, nec cursus lorem. Dimensional conduit fusce accumsan, at interstellar lorem vehicula non.

--- a/docs/foundations/index.md
+++ b/docs/foundations/index.md
@@ -4,11 +4,8 @@
 
 ## Warp Ipsum
 
-<image imageurl="/warp-portal-poc/css/matter.jpg" imgalt="is noice" imgcaption="Beautiful image" aspectratio="4/3" />
-
-
 ::: image-block
-![Beautiful image](/css/matter.jpg)
+![Alt text go here](/css/matter.jpg)
 :::
 
 Nulla portalis magnus quantum fluxus, et interdimensional nexus stabilis. Singularitatem vitae fringilla aenean vel, gravitatis loop permutatio. Non-stop phasing, omni-directional communication relay cursus ut nisl. Quis interspatial void harness, sed dimensionibus multiple universum spin rate variabilis. Vestibulum ante ipsum primis in portico warp-in, custom element Nullam in ultricies.

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "@warp-ds/react": "2.0.1",
     "@warp-ds/uno": "2.0.0",
     "@warp-ds/vue": "2.1.1",
-    "decamelize": "6.0.0",
     "camelcase": "8.0.0",
+    "decamelize": "6.0.0",
     "markdown-it": "14.1.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
@@ -31,5 +31,8 @@
     "vite": "5.3.5",
     "vitepress": "1.3.1",
     "vue": "3.4.34"
+  },
+  "dependencies": {
+    "markdown-it-container": "^4.0.0"
   }
 }


### PR DESCRIPTION
Adds a plugin called markdown-it-container, these makes it possible to define styleable custom markdown containers. 

Markdown syntax for the image block looks like this: 
`::: image-block`
`![Alt text go here](/css/matter.jpg)`
`:::`

Temporary styling:
<img width="1454" alt="image" src="https://github.com/user-attachments/assets/b160eb6d-2e36-431e-8f2b-1d7fee374dc9">
