### PR TITLE
Add structure for warp colored tokens light-dark mode

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,3 +1,24 @@
+
+/*  Warp color tokens  */
+
+/* set light mode colors here as default value */
+:root {
+   --w-bg-color: #ffffff;
+
+}
+
+/* set dark mode color here */
+@media (prefers-color-scheme: dark) {
+  :root{
+    /* --w-bg-color: #000000; */
+  }
+}
+
+body {
+  --vp-c-bg: var(--w-bg-color);
+}
+
+
 :root {
   --vp-c-brand-1: #BE3830;
   --vp-c-brand-2: #c63f36;


### PR DESCRIPTION
Sets up a starting structure for us to add all our colors , and a place to map them to the --vp- tokens.

Sets up the documentsite to do dark/light switching based on user preferences on the device instead of a switch in the header.

When we have our colors in place we can remove all the .dark styling, that is all tied to the theme switch switch in the header, which can also be removed.