### PR TITLE
fix(footer): add link to FAQ page

### DIFF
--- a/docs/.vitepress/Footer.vue
+++ b/docs/.vitepress/Footer.vue
@@ -10,6 +10,7 @@
     </div>
     <div class="footer-column">
       <h3 class="footer-column-title">Help</h3>
+      <a class="footer-link" :href="`${baseUrl}help/faq`">FAQ</a>
       <a class="footer-link" :href="`${baseUrl}help/support`">Support</a>
       <a class="footer-link" :href="`${baseUrl}help/report-bugs`">Report bugs/errors</a>
     </div>


### PR DESCRIPTION
<img width="1083" alt="Screenshot of the footer containing FAQ link under the HELP section" src="https://github.com/user-attachments/assets/63163d1a-1f20-45e7-a202-c2912f982ea3">
