### PR TITLE
fix(home-page): fix url in the tokens card

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ const componentData = [
   },
   {
     title: 'Tokens',
-    href: 'foundations/tokens',
+    href: 'foundations/tokens/intro/',
     image: { component: TokensCard, alt: 'Two abstract shapes in grey and black colors, one bigger than the other' },
     description: 'Discover design tokens for managing color, typography, and spacing'
   }


### PR DESCRIPTION
We don't show anything under [foundations/tokens/](https://warp-ds.github.io/warp-portal-poc/foundations/tokens), because the actual content is located under [foundations/tokens/intro/](https://warp-ds.github.io/warp-portal-poc/foundations/tokens/intro/). This PR fixes the url :) 