### PR TITLE
Adjust table widths.

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -169,6 +169,17 @@ html.dark body {
 .vp-doc p {
   line-height: 1.5;
 }
+/* Ensure tables behave like tables and take full width */
+.vp-doc table {
+  display: table;   /* Override any display: block */
+  min-width: 100%;  /* Ensure the table is at least 100% of its container */
+}
+
+/* Wrap tables inside a container to handle horizontal overflow */
+.vp-doc .table-container {
+  overflow-x: auto;
+  width: 100%;  /* Ensure the container itself takes up the full width */
+}
 
 .line-through {
   text-decoration-line: line-through;


### PR DESCRIPTION
Tables now use the full width of their parent.

wrap a table in something class="table-container"  if your table cannot shrinc below mobile width, this will cause it to automagically get a horizontal scroll. 

Before: 
<img width="958" alt="image" src="https://github.com/user-attachments/assets/043d9f22-c974-4411-b4c0-be700821d022">

After: 
<img width="1049" alt="image" src="https://github.com/user-attachments/assets/01db1a97-1270-42f2-b8e7-acf12dfdd91c">
