### PR TITLE
fix(config): remove '/src' from editLink path

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -187,7 +187,7 @@ export default defineConfig({
   themeConfig: {
     lastUpdated: true, // Add this to show the last updated timestamp
     editLink: {
-      pattern: 'https://github.com/warp-ds/warp-portal-poc/edit/main/docs/src/:path' // Edit link for GitHub
+      pattern: 'https://github.com/warp-ds/warp-portal-poc/edit/main/docs/:path' // Edit link for GitHub
     },
     search: { provider: 'local' },
     logo: '/warp-logo-small.svg',


### PR DESCRIPTION
This PR fixes the path to markdown files on Github when the "Edit this page" link is pressed on respective pages.

Part of [WARP-627](https://nmp-jira.atlassian.net/browse/WARP-627)