### PR TITLE
fix(config): fix icon color path

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -349,7 +349,7 @@ export default defineConfig({
                     text: 'Iconography',
                     collapsed: true,
                     items: [
-                      { text: 'Icon Color', link: 'foundations/foundations/styling/web/icon-color' },
+                      { text: 'Icon Color', link: '/foundations/styling/web/icon-color' },
                     ],
                   },
                   {


### PR DESCRIPTION
This PR fixes a broken side-menu link to Icon Color page.
Part of [WARP-627](https://nmp-jira.atlassian.net/browse/WARP-627)