### PR TITLE
Add light suffix to the themeswitch light choices

### DIFF
--- a/docs/.vitepress/warp-theme-switcher.js
+++ b/docs/.vitepress/warp-theme-switcher.js
@@ -1,25 +1,35 @@
-import { computed, reactive } from "vue";
+import { computed, reactive } from 'vue';
 
 export default {
   install: (app) => {
     const themes = {
-      'DBA': 'dba-dk',
-      'Finn': 'finn-no',
-      'Tori': 'tori-fi'
+      'DBA light': 'dba-dk',
+      'Finn light': 'finn-no',
+      'Tori light': 'tori-fi',
     };
 
     const state = reactive({
-      currentTheme: (typeof window !== 'undefined' && localStorage.getItem('warpTheme')) || themes.Finn
+      currentTheme:
+        (typeof window !== 'undefined' &&
+          localStorage.getItem('warpTheme')) ||
+        themes.Finn,
     });
 
     const rewriteStylesheets = (theme) => {
-      const roots = [document, ...Array.from(document.querySelectorAll('*')).filter((el) => !!el.shadowRoot).map((el) => el.shadowRoot)];
+      const roots = [
+        document,
+        ...Array.from(document.querySelectorAll('*'))
+          .filter((el) => !!el.shadowRoot)
+          .map((el) => el.shadowRoot),
+      ];
       roots.forEach((root) => {
-        const stylesheets = root.querySelectorAll('link[rel="stylesheet"][href*="/@warp-ds/css/"]');
+        const stylesheets = root.querySelectorAll(
+          'link[rel="stylesheet"][href*="/@warp-ds/css/"]'
+        );
         stylesheets.forEach((s) => {
           s.setAttribute(
             'href',
-            `https://assets.finn.no/pkg/@warp-ds/css/v2/tokens/${theme}.css`,
+            `https://assets.finn.no/pkg/@warp-ds/css/v2/tokens/${theme}.css`
           );
         });
       });
@@ -27,14 +37,14 @@ export default {
 
     const updateTheme = (theme) => {
       localStorage.setItem('warpTheme', theme);
-      state.currentTheme = theme;  // Update the reactive state
+      state.currentTheme = theme; // Update the reactive state
       rewriteStylesheets(theme);
     };
 
     app.provide('warpThemeSwitcher', {
       themes,
       current: computed(() => state.currentTheme),
-      updateTheme
+      updateTheme,
     });
 
     // Listen for storage changes
@@ -46,5 +56,5 @@ export default {
         }
       });
     }
-  }
-}
+  },
+};


### PR DESCRIPTION
<img width="423" alt="image" src="https://github.com/user-attachments/assets/6babdce9-b5a7-487b-9322-a519168fdeff">


Just implying how light dark brand controll should be implemented :)   They can be optionally be called   finn/finn dark   when we add dark 