### PR TITLE
fix(docs): correct link to Text field components in Datepicker overview

### DIFF
--- a/docs/components/datepicker/overview.md
+++ b/docs/components/datepicker/overview.md
@@ -11,7 +11,7 @@ import { mapFrameworkStatuses } from '../utils.js';
 
 The date picker consists of a text field and a popover calendar panel. It is designed to allow users to select a single date in a clean, accessible manner. The popover appears upon click/tap and closes on date selection or when the user clicks/taps outside the popover.
 
-Related components: [Text field](/components/textfield)
+Related components: [Text field](../textfield/index.md)
 
 ## Platform & Framework Support
 


### PR DESCRIPTION
Fix breaking build