### PR TITLE
docs: Add s-border-strong and s-border-strong-hover 

### DIFF
--- a/docs/supported.list.js
+++ b/docs/supported.list.js
@@ -178,6 +178,8 @@ export const borderColor = [
   's-border-inverted',
   's-border-focus', // Added in v2
   's-border-focused', // Removed in v2
+  's-border-strong',
+  's-border-strong-hover',
   's-border-primary',
   's-border-primary-hover',
   's-border-primary-active',


### PR DESCRIPTION
warp-1139  Add s-border-strong, and s-border-strong-hover to supported class list.
<img width="726" height="130" alt="image" src="https://github.com/user-attachments/assets/c7770aea-1e7b-4384-91da-c22c3aad7ab2" />
