### PR TITLE
docs: Add s-surface documentation

### DIFF
--- a/docs/.vitepress/bootExamples.js
+++ b/docs/.vitepress/bootExamples.js
@@ -100,6 +100,11 @@ buildWc('example-container');
 buildWc('background-color-table', QrColorTable, {
   dataId: 'backgroundColor',
 });
+
+buildWc('surface-color-table', QrColorTable, {
+  dataId: 'surfaceColor',
+});
+
 buildWc('border-color-table', QrColorTable, {
   dataId: 'borderColor',
 });

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -753,6 +753,16 @@ export default defineConfig({
                   ],
                 },
                 {
+                  text: 'Elevation',
+                  collapsed: true,
+                  items: [
+                    {
+                      text: 'surface',
+                      link: '/foundations/css-classes/surface',
+                    },
+                  ],
+                },
+                {
                   text: 'Spacing',
                   collapsed: true,
                   items: [

--- a/docs/foundations/css-classes/surface.md
+++ b/docs/foundations/css-classes/surface.md
@@ -1,0 +1,47 @@
+> Elevation
+
+# Surface
+
+A concept used to visually differentiate the height (or depth) between elements.
+
+::: tip s-prefix
+The `s-` (semantic) prefix signals that the color value of these will change with the brand css.
+:::
+
+## Quick reference
+
+<surface-color-table />
+
+## Basic usage
+
+### Usage guide
+Refer to the [Elevation guide](/foundations/elevation/) for more information about when to use elevation and when not to.
+
+### Setting the elevation
+Control the elevation of an element using the `s-surface-{sunken|elevated-100|elevated-200|elevated-300}` utilities as specified in the table above.
+
+<ThemeSwitcher />
+<example-container>
+  <div class="s-bg s-text p-32">
+    <div class="s-bg pb-32">.s-bg</div>
+    <div class="s-surface-sunken p-16 mb-32 rounded-4">.s-surface-sunken</div>
+    <div class="s-surface-elevated-100 p-16 mb-32 rounded-4">.s-surface-elevated-100</div>
+    <div class="s-surface-elevated-200 p-16 mb-32 rounded-4">.s-surface-elevated-200</div>
+    <div class="s-surface-elevated-300 p-16 mb-32 rounded-4">.s-surface-elevated-300</div>
+    <div class="s-surface-elevated-100 p-16 rounded-4"><div>.s-surface-elevated-100</div>
+      <div class="s-surface-elevated-200 p-16 rounded-4"><div>.s-surface-elevated-200</div>
+        <div class="s-surface-elevated-300 p-16 rounded-4"><div>.s-surface-elevated-300</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</example-container>
+
+```html
+<div class="s-bg ...">
+  <div class="s-surface-sunken ..."></div>
+  <div class="s-surface-elevated-100 ..."></div>
+  <div class="s-surface-elevated-200 ..."></div>
+  <div class="s-surface-elevated-300 ..."></div>
+</div>
+```

--- a/docs/supported.list.js
+++ b/docs/supported.list.js
@@ -131,6 +131,13 @@ export const backgroundColor = [
   's-bg-notification',
 ];
 
+export const surfaceColor = [
+  's-surface-sunken',
+  's-surface-elevated-100',
+  's-surface-elevated-200',
+  's-surface-elevated-300',
+];
+
 export const backgroundOrigin = ['bg-origin-border', 'bg-origin-padding', 'bg-origin-content'];
 
 export const backgroundPosition = [


### PR DESCRIPTION
Add documentation for s-surface classes.
Add brandselector

<img width="1444" height="993" alt="image" src="https://github.com/user-attachments/assets/180c2f78-c65a-48ed-aa97-52ea117c6497" />
<img width="1581" height="992" alt="image" src="https://github.com/user-attachments/assets/2fa875d3-b3ee-4f99-9767-e6fd321e2f87" />
<img width="1447" height="993" alt="image" src="https://github.com/user-attachments/assets/e8560104-bc19-4993-8e05-6b208e0b8bb0" />
