### PR TITLE
Blog info about iOS Warp version `0.0.68`

### DIFF
--- a/docs/blog/posts/2025/ios-0.0.68.md
+++ b/docs/blog/posts/2025/ios-0.0.68.md
@@ -3,7 +3,7 @@ title: 'WARP iOS release v.0.0.68'
 date: 2025-10-30
 ---
 
-Selector component & Icon updates
+Select component & Icon updates
 ---
 
 # Warp iOS release 0.0.68


### PR DESCRIPTION
## Why? ##

New iOS Warp release - `0.0.68`

## What? ##

- `Select` component
- new & updated icons
- fix tappable area inside `TextField` & `TextArea`