### PR TITLE
Blog entry for Android Warp `0.0.52`

### DIFF
--- a/docs/blog/posts/2026/android-0.0.52.md
+++ b/docs/blog/posts/2026/android-0.0.52.md
@@ -1,0 +1,25 @@
+---
+title: 'WARP Android release v.0.0.52'
+date: 2026-01-21
+---
+
+New icons and style tokens update
+
+---
+
+# Warp Android release 0.0.52
+
+## 2026-01-21
+
+#### New icons
+
+- MicrophoneSlash
+- Microphone
+- Translate
+
+#### Style tokens update
+
+- DBA Dark mode fix
+    - Icon-, Background- and Border-Secondary tokens changed to Pthaloblue-300 (before 400).
+    - Secondary-Hover token changed to Pthaloblue-200 (before 300).
+    - Secondary-Active token changed to Pthaloblue-100 (before 200).

--- a/docs/blog/posts/2026/ios-0.0.71.md
+++ b/docs/blog/posts/2026/ios-0.0.71.md
@@ -3,7 +3,7 @@ title: 'WARP iOS release v.0.0.71'
 date: 2026-01-20
 ---
 
-StateView component
+New icons and style tokens update
 
 ---
 


### PR DESCRIPTION
- fix entry for iOS entry 0.0.72 (header leftover)