### PR TITLE
Fix landing page icons URL

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ const cardData = {
     },
     {
       title: 'Icons',
-      href: 'components/icons',
+      href: 'components/icons/overview',
       image: { component: IconsCard, alt: 'Three talk bubbles that are smiling and have closed eyes' },
       description: 'Browse our library of UI icons',
     },


### PR DESCRIPTION
Small fix to correct the incorrect icons URL on the landing page.

Slack: https://sch-chat.slack.com/archives/C04NF2K46LB/p1769093864238309