### PR TITLE
Search and navigation

### DIFF
--- a/docs/.vitepress/sidebar-generator.js
+++ b/docs/.vitepress/sidebar-generator.js
@@ -42,15 +42,14 @@ function generateItemSidebar(type, name) {
   const items = [];
 
   for (const page of pageTypes) {
-    if (page.isFrameworks) {
-      // For frameworks, link to the first framework file
-      if (frameworks.length > 0) {
-        const firstFramework = frameworks[0].file;
-        items.push({
-          text: page.text,
-          link: `/${type}/${name}/frameworks/${firstFramework}`,
-        });
-      }
+    if (page.isFrameworks && frameworks.length > 0) {
+      items.push({
+        text: 'Frameworks',
+        items: frameworks.map((entry) => ({
+          text: entry.name,
+          link: `/${type}/${name}/frameworks/${entry.file}`,
+        })),
+      });
     } else {
       // Check if the page file exists
       const pagePath = join(itemDir, `${page.file}.md`);

--- a/docs/blog/posts.data.js
+++ b/docs/blog/posts.data.js
@@ -15,6 +15,10 @@ export default createContentLoader('/blog/posts/**/*.md', {
       })
       .map((page) => ({
         ...page,
+        frontmatter: {
+          ...page.frontmatter,
+          search: false,
+        },
         url: `${base}${page.url}`,
       }));
   },

--- a/docs/components/alert/frameworks/android.md
+++ b/docs/components/alert/frameworks/android.md
@@ -1,4 +1,4 @@
-# Alert - Frameworks
+# Alert - Android
 Alerts show high-signal messages meant to be noticed and prompting users.
 
 <ComponentsStatus />

--- a/docs/components/alert/frameworks/elements.md
+++ b/docs/components/alert/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Alert - Frameworks
+# Alert - Elements
 Alerts show high-signal messages meant to be noticed and prompting users.
 
 <ComponentsStatus />

--- a/docs/components/alert/frameworks/ios.md
+++ b/docs/components/alert/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Alert - Frameworks
+# Alert - iOS
 Alerts show high-signal messages meant to be noticed and prompting users.
 
 <ComponentsStatus />

--- a/docs/components/alert/frameworks/react-19.md
+++ b/docs/components/alert/frameworks/react-19.md
@@ -1,4 +1,4 @@
-# Alert - Frameworks
+# Alert - React 19
 Alerts show high-signal messages meant to be noticed and prompting users.
 
 <ComponentsStatus />

--- a/docs/components/alert/frameworks/react.md
+++ b/docs/components/alert/frameworks/react.md
@@ -1,4 +1,4 @@
-# Alert - Frameworks
+# Alert - React
 Alerts show high-signal messages meant to be noticed and prompting users.
 
 <ComponentsStatus />

--- a/docs/components/alert/frameworks/vue.md
+++ b/docs/components/alert/frameworks/vue.md
@@ -1,4 +1,4 @@
-# Alert - Frameworks
+# Alert - Vue
 Alerts show high-signal messages meant to be noticed and prompting users.
 
 <ComponentsStatus />

--- a/docs/components/badge/frameworks/android.md
+++ b/docs/components/badge/frameworks/android.md
@@ -1,4 +1,4 @@
-# Badge - Frameworks
+# Badge - Android
 
 Badges are used to highlight a relevant piece of information, like status or category.
 

--- a/docs/components/badge/frameworks/elements.md
+++ b/docs/components/badge/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Badge - Frameworks
+# Badge - Elements
 
 Badges are used to highlight a relevant piece of information, like status or category.
 

--- a/docs/components/badge/frameworks/ios.md
+++ b/docs/components/badge/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Badge - Frameworks
+# Badge - iOS
 
 Badges are used to highlight a relevant piece of information, like status or category.
 

--- a/docs/components/badge/frameworks/react.md
+++ b/docs/components/badge/frameworks/react.md
@@ -1,4 +1,4 @@
-# Badge - Frameworks
+# Badge - React
 
 Badges are used to highlight a relevant piece of information, like status or category.
 

--- a/docs/components/badge/frameworks/vue.md
+++ b/docs/components/badge/frameworks/vue.md
@@ -1,4 +1,4 @@
-# Badge - Frameworks
+# Badge - Vue
 
 Badges are used to highlight a relevant piece of information, like status or category.
 

--- a/docs/components/box/frameworks/android.md
+++ b/docs/components/box/frameworks/android.md
@@ -1,4 +1,4 @@
-# Box - Frameworks
+# Box - Android
 Box is a layout component used for separating content areas on a page.
 
 <ComponentsStatus />

--- a/docs/components/box/frameworks/elements.md
+++ b/docs/components/box/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Box - Frameworks
+# Box - Elements
 Box is a layout component used for separating content areas on a page.
 
 <ComponentsStatus />

--- a/docs/components/box/frameworks/ios.md
+++ b/docs/components/box/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Box - Frameworks
+# Box - iOS
 Box is a layout component used for separating content areas on a page.
 
 <ComponentsStatus />

--- a/docs/components/box/frameworks/react.md
+++ b/docs/components/box/frameworks/react.md
@@ -1,4 +1,4 @@
-# Box - Frameworks
+# Box - React
 Box is a layout component used for separating content areas on a page.
 
 <ComponentsStatus />

--- a/docs/components/box/frameworks/vue.md
+++ b/docs/components/box/frameworks/vue.md
@@ -1,4 +1,4 @@
-# Box - Frameworks
+# Box - Vue
 Box is a layout component used for separating content areas on a page.
 
 <ComponentsStatus />

--- a/docs/components/breadcrumbs/frameworks/elements.md
+++ b/docs/components/breadcrumbs/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Breadcrumbs - Frameworks
+# Breadcrumbs - Elements
 Breadcrumbs show users their current location relative to the information architecture and enable them to quickly move up to a parent level or previous step. 
 
 <ComponentsStatus />

--- a/docs/components/breadcrumbs/frameworks/react.md
+++ b/docs/components/breadcrumbs/frameworks/react.md
@@ -1,4 +1,4 @@
-# Breadcrumbs - Frameworks
+# Breadcrumbs - React
 Breadcrumbs show users their current location relative to the information architecture and enable them to quickly move up to a parent level or previous step. 
 
 <ComponentsStatus />

--- a/docs/components/breadcrumbs/frameworks/vue.md
+++ b/docs/components/breadcrumbs/frameworks/vue.md
@@ -1,4 +1,4 @@
-# Breadcrumbs - Frameworks
+# Breadcrumbs - Vue
 Breadcrumbs show users their current location relative to the information architecture and enable them to quickly move up to a parent level or previous step. 
 
 <ComponentsStatus />

--- a/docs/components/broadcast/frameworks/ios.md
+++ b/docs/components/broadcast/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Broadcast - Frameworks
+# Broadcast - iOS
 Broadcast automatically fetches broadcast messages for the current (or a given) url.
 
 <ComponentsStatus />

--- a/docs/components/button-group/frameworks/ios.md
+++ b/docs/components/button-group/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Button group - Frameworks
+# Button group - iOS
 Button group is a grouping concept for buttons.
 
 <ComponentsStatus />

--- a/docs/components/button-group/frameworks/vue.md
+++ b/docs/components/button-group/frameworks/vue.md
@@ -1,4 +1,4 @@
-# Button group - Frameworks
+# Button group - Vue
 Button group is a grouping concept for buttons.
 
 <ComponentsStatus />

--- a/docs/components/button-pill/frameworks/ios.md
+++ b/docs/components/button-pill/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Button Pill - Frameworks
+# Button Pill - iOS
 Button pill allows users to toggle an element to their favourites.
 
 <ComponentsStatus />

--- a/docs/components/button/frameworks/android.md
+++ b/docs/components/button/frameworks/android.md
@@ -1,4 +1,4 @@
-# Button - Frameworks
+# Button - Android
 Buttons initiate events or actions within a page, informing users of what to expect next.
 
 <ComponentsStatus />

--- a/docs/components/button/frameworks/elements.md
+++ b/docs/components/button/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Button - Frameworks
+# Button - Elements
 Buttons initiate events or actions within a page, informing users of what to expect next.
 
 <ComponentsStatus />

--- a/docs/components/button/frameworks/ios.md
+++ b/docs/components/button/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Button - Frameworks
+# Button - iOS
 Buttons initiate events or actions within a page, informing users of what to expect next.
 
 <ComponentsStatus />

--- a/docs/components/button/frameworks/react-19.md
+++ b/docs/components/button/frameworks/react-19.md
@@ -1,4 +1,4 @@
-# Button - Frameworks
+# Button - React 19
 Buttons initiate events or actions within a page, informing users of what to expect next.
 
 <ComponentsStatus />

--- a/docs/components/button/frameworks/react.md
+++ b/docs/components/button/frameworks/react.md
@@ -1,4 +1,4 @@
-# Button - Frameworks
+# Button - React
 Buttons initiate events or actions within a page, informing users of what to expect next.
 
 <ComponentsStatus />

--- a/docs/components/button/frameworks/vue.md
+++ b/docs/components/button/frameworks/vue.md
@@ -1,4 +1,4 @@
-# Button - Frameworks
+# Button - Vue
 Buttons initiate events or actions within a page, informing users of what to expect next.
 
 <ComponentsStatus />

--- a/docs/components/callout/frameworks/android.md
+++ b/docs/components/callout/frameworks/android.md
@@ -1,4 +1,4 @@
-# Callout - Frameworks
+# Callout - Android
 Callouts are snippets of information, drawing attention to important content.
 
 <ComponentsStatus />

--- a/docs/components/callout/frameworks/elements.md
+++ b/docs/components/callout/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Callout - Frameworks
+# Callout - Elements
 Callouts are snippets of information, drawing attention to important content.
 
 <ComponentsStatus />

--- a/docs/components/callout/frameworks/ios.md
+++ b/docs/components/callout/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Callout - Frameworks
+# Callout - iOS
 Callouts are snippets of information, drawing attention to important content.
 
 <ComponentsStatus />

--- a/docs/components/callout/frameworks/react.md
+++ b/docs/components/callout/frameworks/react.md
@@ -1,4 +1,4 @@
-# Callout - Frameworks
+# Callout - React
 Callouts are snippets of information, drawing attention to important content.
 
 <ComponentsStatus />

--- a/docs/components/callout/frameworks/vue.md
+++ b/docs/components/callout/frameworks/vue.md
@@ -1,4 +1,4 @@
-# Callout - Frameworks
+# Callout - Vue
 Callouts are snippets of information, drawing attention to important content.
 
 <ComponentsStatus />

--- a/docs/components/card/frameworks/elements.md
+++ b/docs/components/card/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Card - Frameworks
+# Card - Elements
 Card is an interactive layout component to display information.
 
 <ComponentsStatus />

--- a/docs/components/card/frameworks/react.md
+++ b/docs/components/card/frameworks/react.md
@@ -1,4 +1,4 @@
-# Card - Frameworks
+# Card - React
 Card is an interactive layout component to display information.
 
 <ComponentsStatus />

--- a/docs/components/card/frameworks/vue.md
+++ b/docs/components/card/frameworks/vue.md
@@ -1,4 +1,4 @@
-# Card - Frameworks
+# Card - Vue
 Card is an interactive layout component to display information.
 
 <ComponentsStatus />

--- a/docs/components/checkbox/frameworks/android.md
+++ b/docs/components/checkbox/frameworks/android.md
@@ -1,4 +1,4 @@
-# Checkbox - Frameworks
+# Checkbox - Android
 Checkboxes allow users to select one or more options from a number of choices.
 
 <ComponentsStatus />

--- a/docs/components/checkbox/frameworks/elements.md
+++ b/docs/components/checkbox/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Checkbox - Frameworks
+# Checkbox - Elements
 Checkboxes allow users to select one or more options from a number of choices.
 
 <ComponentsStatus />

--- a/docs/components/checkbox/frameworks/ios.md
+++ b/docs/components/checkbox/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Checkbox - Frameworks
+# Checkbox - iOS
 Checkboxes allow users to select one or more options from a number of choices.
 
 <ComponentsStatus />

--- a/docs/components/checkbox/frameworks/react.md
+++ b/docs/components/checkbox/frameworks/react.md
@@ -1,4 +1,4 @@
-# Checkbox - Frameworks
+# Checkbox - React
 Checkboxes allow users to select one or more options from a number of choices.
 
 <ComponentsStatus />

--- a/docs/components/checkbox/frameworks/vue.md
+++ b/docs/components/checkbox/frameworks/vue.md
@@ -1,4 +1,4 @@
-# Checkbox - Frameworks
+# Checkbox - Vue
 Checkboxes allow users to select one or more options from a number of choices.
 
 <ComponentsStatus />

--- a/docs/components/combo-box/frameworks/elements.md
+++ b/docs/components/combo-box/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Combo box - Frameworks
+# Combo box - Elements
 A combo box combines a dropdown list with an editable text input, allowing users to either select an option or type their own.
 
 <ComponentsStatus />

--- a/docs/components/combo-box/frameworks/react.md
+++ b/docs/components/combo-box/frameworks/react.md
@@ -1,4 +1,4 @@
-# Combo box - Frameworks
+# Combo box - React
 A combo box combines a dropdown list with an editable text input, allowing users to either select an option or type their own.
 
 <ComponentsStatus />

--- a/docs/components/date-picker/frameworks/android.md
+++ b/docs/components/date-picker/frameworks/android.md
@@ -1,4 +1,4 @@
-# Date picker - Frameworks
+# Date picker - Android
 A date picker allows the user to select a specific calendar date.
 
 <ComponentsStatus />

--- a/docs/components/date-picker/frameworks/elements.md
+++ b/docs/components/date-picker/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Date picker - Frameworks
+# Date picker - Elements
 A date picker allows the user to select a specific calendar date.
 
 <ComponentsStatus />

--- a/docs/components/date-picker/frameworks/ios.md
+++ b/docs/components/date-picker/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Date picker - Frameworks
+# Date picker - iOS
 A date picker allows the user to select a specific calendar date.
 
 <ComponentsStatus />

--- a/docs/components/date-picker/frameworks/react-19.md
+++ b/docs/components/date-picker/frameworks/react-19.md
@@ -1,4 +1,4 @@
-# Date picker - Frameworks
+# Date picker - React 19
 A date picker allows the user to select a specific calendar date.
 
 <ComponentsStatus />

--- a/docs/components/divider/frameworks/android.md
+++ b/docs/components/divider/frameworks/android.md
@@ -1,4 +1,4 @@
-# Divider - Frameworks
+# Divider - Android
 A divider creates separation of content.
 
 <ComponentsStatus />

--- a/docs/components/divider/frameworks/ios.md
+++ b/docs/components/divider/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Divider - Frameworks
+# Divider - iOS
 A divider creates separation of content.
 
 <ComponentsStatus />

--- a/docs/components/expandable/frameworks/android.md
+++ b/docs/components/expandable/frameworks/android.md
@@ -1,4 +1,4 @@
-# Expandable - Frameworks
+# Expandable - Android
 Expandable is a layout component used for creating content that can be expanded and collapsed.
 
 <ComponentsStatus />

--- a/docs/components/expandable/frameworks/elements.md
+++ b/docs/components/expandable/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Expandable - Frameworks
+# Expandable - Elements
 Expandable is a layout component used for creating content that can be expanded and collapsed.
 
 <ComponentsStatus />

--- a/docs/components/expandable/frameworks/ios.md
+++ b/docs/components/expandable/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Expandable - Frameworks
+# Expandable - iOS
 Expandable is a layout component used for creating content that can be expanded and collapsed.
 
 <ComponentsStatus />

--- a/docs/components/expandable/frameworks/react.md
+++ b/docs/components/expandable/frameworks/react.md
@@ -1,4 +1,4 @@
-# Expandable - Frameworks
+# Expandable - React
 Expandable is a layout component used for creating content that can be expanded and collapsed.
 
 <ComponentsStatus />

--- a/docs/components/expandable/frameworks/vue.md
+++ b/docs/components/expandable/frameworks/vue.md
@@ -1,4 +1,4 @@
-# Expandable - Frameworks
+# Expandable - Vue
 Expandable is a layout component used for creating content that can be expanded and collapsed.
 
 <ComponentsStatus />

--- a/docs/components/icons/frameworks/android.md
+++ b/docs/components/icons/frameworks/android.md
@@ -1,4 +1,4 @@
-# Icons - Frameworks
+# Icons - Android
 Warp’s icons are crafted to deliver consistency, clarity, and scalability across our multi-brand product ecosystem.
 
 <ComponentsStatus />

--- a/docs/components/icons/frameworks/elements.md
+++ b/docs/components/icons/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Icons - Frameworks
+# Icons - Elements
 Warp’s icons are crafted to deliver consistency, clarity, and scalability across our multi-brand product ecosystem.
 
 <ComponentsStatus />

--- a/docs/components/icons/frameworks/ios.md
+++ b/docs/components/icons/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Icons - Frameworks
+# Icons - iOS
 Warp’s icons are crafted to deliver consistency, clarity, and scalability across our multi-brand product ecosystem.
 
 <ComponentsStatus />

--- a/docs/components/icons/frameworks/react-19.md
+++ b/docs/components/icons/frameworks/react-19.md
@@ -1,4 +1,4 @@
-# Icons - Frameworks
+# Icons - React 19
 Warp’s icons are crafted to deliver consistency, clarity, and scalability across our multi-brand product ecosystem.
 
 <ComponentsStatus />

--- a/docs/components/link/frameworks/android.md
+++ b/docs/components/link/frameworks/android.md
@@ -1,4 +1,4 @@
-# Link - Frameworks
+# Link - Android
 Link component to use when creating links that look like buttons.
 
 <ComponentsStatus />

--- a/docs/components/link/frameworks/elements.md
+++ b/docs/components/link/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Link - Frameworks
+# Link - Elements
 Link component to use when creating links that look like buttons.
 
 <ComponentsStatus />

--- a/docs/components/link/frameworks/react-19.md
+++ b/docs/components/link/frameworks/react-19.md
@@ -1,4 +1,4 @@
-# Link - Frameworks
+# Link - React 19
 Link component to use when creating links that look like buttons.
 
 <ComponentsStatus />

--- a/docs/components/logo/frameworks/android.md
+++ b/docs/components/logo/frameworks/android.md
@@ -1,4 +1,4 @@
-# Logo - Frameworks
+# Logo - Android
 Vend's logos are crafted to deliver consistency, clarity, and scalability across our multi-brand product ecosystem.
 
 <ComponentsStatus />

--- a/docs/components/logo/frameworks/ios.md
+++ b/docs/components/logo/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Logo - Frameworks
+# Logo - iOS
 Vend's logos are crafted to deliver consistency, clarity, and scalability across our multi-brand product ecosystem.
 
 <ComponentsStatus />

--- a/docs/components/modal/frameworks/android.md
+++ b/docs/components/modal/frameworks/android.md
@@ -1,4 +1,4 @@
-# Modal - Frameworks
+# Modal - Android
 A modal is a focused dialog that temporarily blocks the interface to request a specific decision or input. Because it pauses the experience, use it sparingly for high-priority tasks.
 
 <ComponentsStatus />

--- a/docs/components/modal/frameworks/elements.md
+++ b/docs/components/modal/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Modal - Frameworks
+# Modal - Elements
 A modal is a focused dialog that temporarily blocks the interface to request a specific decision or input. Because it pauses the experience, use it sparingly for high-priority tasks.
 
 <ComponentsStatus />

--- a/docs/components/modal/frameworks/ios.md
+++ b/docs/components/modal/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Modal - Frameworks
+# Modal - iOS
 A modal is a focused dialog that temporarily blocks the interface to request a specific decision or input. Because it pauses the experience, use it sparingly for high-priority tasks.
 
 <ComponentsStatus />

--- a/docs/components/modal/frameworks/react.md
+++ b/docs/components/modal/frameworks/react.md
@@ -1,4 +1,4 @@
-# Modal - Frameworks
+# Modal - React
 A modal is a focused dialog that temporarily blocks the interface to request a specific decision or input. Because it pauses the experience, use it sparingly for high-priority tasks.
 
 <ComponentsStatus />

--- a/docs/components/modal/frameworks/vue.md
+++ b/docs/components/modal/frameworks/vue.md
@@ -1,4 +1,4 @@
-# Modal - Frameworks
+# Modal - Vue
 A modal is a focused dialog that temporarily blocks the interface to request a specific decision or input. Because it pauses the experience, use it sparingly for high-priority tasks.
 
 <ComponentsStatus />

--- a/docs/components/page-indicator/frameworks/android.md
+++ b/docs/components/page-indicator/frameworks/android.md
@@ -1,4 +1,4 @@
-# Page indicator - Frameworks
+# Page indicator - Android
 A page indicator shows the total amount of pages (or images) and the current page using dots.
 
 <ComponentsStatus />

--- a/docs/components/page-indicator/frameworks/elements.md
+++ b/docs/components/page-indicator/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Page indicator - Frameworks
+# Page indicator - Elements
 A page indicator shows the total amount of pages (or images) and the current page using dots.
 
 <ComponentsStatus />

--- a/docs/components/page-indicator/frameworks/ios.md
+++ b/docs/components/page-indicator/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Page indicator - Frameworks
+# Page indicator - iOS
 A page indicator shows the total amount of pages (or images) and the current page using dots.
 
 <ComponentsStatus />

--- a/docs/components/page-indicator/frameworks/react-19.md
+++ b/docs/components/page-indicator/frameworks/react-19.md
@@ -1,4 +1,4 @@
-# Page indicator - Frameworks
+# Page indicator - React 19
 A page indicator shows the total amount of pages (or images) and the current page using dots.
 
 <ComponentsStatus />

--- a/docs/components/pagination/frameworks/elements.md
+++ b/docs/components/pagination/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Pagination - Frameworks
+# Pagination - Elements
 Pagination allows users to navigate through multiple pages of content by providing navigation controls with page numbers and directional arrows.
 
 <ComponentsStatus />

--- a/docs/components/pagination/frameworks/react.md
+++ b/docs/components/pagination/frameworks/react.md
@@ -1,4 +1,4 @@
-# Pagination - Frameworks
+# Pagination - React
 Pagination is used to split up long datasets into multiple 'pages'.
 
 <ComponentsStatus />

--- a/docs/components/pill/frameworks/android.md
+++ b/docs/components/pill/frameworks/android.md
@@ -1,4 +1,4 @@
-# Pill - Frameworks
+# Pill - Android
 Pill is a type of button that is often used as a filter, but can also be used as a rounded button for overlays, etc.
 
 <ComponentsStatus />

--- a/docs/components/pill/frameworks/elements.md
+++ b/docs/components/pill/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Pill - Frameworks
+# Pill - Elements
 Pill is a type of button that is often used as a filter, but can also be used as a rounded button for overlays, etc.
 
 <ComponentsStatus />

--- a/docs/components/pill/frameworks/ios.md
+++ b/docs/components/pill/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Pill - Frameworks
+# Pill - iOS
 Pill is a type of button that is often used as a filter, but can also be used as a rounded button for overlays, etc.
 
 <ComponentsStatus />

--- a/docs/components/pill/frameworks/react.md
+++ b/docs/components/pill/frameworks/react.md
@@ -1,4 +1,4 @@
-# Pill - Frameworks
+# Pill - React
 Pill is a type of button that is often used as a filter, but can also be used as a rounded button for overlays, etc.
 
 <ComponentsStatus />

--- a/docs/components/pill/frameworks/vue.md
+++ b/docs/components/pill/frameworks/vue.md
@@ -1,4 +1,4 @@
-# Pill - Frameworks
+# Pill - Vue
 Pill is a type of button that is often used as a filter, but can also be used as a rounded button for overlays, etc.
 
 <ComponentsStatus />

--- a/docs/components/popover/frameworks/android.md
+++ b/docs/components/popover/frameworks/android.md
@@ -1,4 +1,4 @@
-# Popover - Frameworks
+# Popover - Android
 A Popover is a message box that is displayed floating over page content after pressing a trigger element, like an info-icon.
 
 <ComponentsStatus />

--- a/docs/components/popover/frameworks/elements.md
+++ b/docs/components/popover/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Popover - Frameworks
+# Popover - Elements
 A Popover is a message box that is displayed floating over page content after pressing a trigger element, like an info-icon.
 
 <ComponentsStatus />

--- a/docs/components/popover/frameworks/react.md
+++ b/docs/components/popover/frameworks/react.md
@@ -1,4 +1,4 @@
-# Popover - Frameworks
+# Popover - React
 A Popover is a message box that is displayed floating over page content after pressing a trigger element, like an info-icon.
 
 <ComponentsStatus />

--- a/docs/components/popover/frameworks/vue.md
+++ b/docs/components/popover/frameworks/vue.md
@@ -1,4 +1,4 @@
-# Popover - Frameworks
+# Popover - Vue
 A Popover is a message box that is displayed floating over page content after pressing a trigger element, like an info-icon.
 
 <ComponentsStatus />

--- a/docs/components/radio-buttons/frameworks/react.md
+++ b/docs/components/radio-buttons/frameworks/react.md
@@ -1,4 +1,4 @@
-# Radio buttons - Frameworks
+# Radio buttons - React
 Radio buttons allow users to select a single option from a button group.
 
 <ComponentsStatus />

--- a/docs/components/radio-buttons/frameworks/vue.md
+++ b/docs/components/radio-buttons/frameworks/vue.md
@@ -1,4 +1,4 @@
-# Radio buttons - Frameworks
+# Radio buttons - Vue
 Radio buttons allow users to select a single option from a button group.
 
 <ComponentsStatus />

--- a/docs/components/radio/frameworks/android.md
+++ b/docs/components/radio/frameworks/android.md
@@ -1,4 +1,4 @@
-# Radio - Frameworks
+# Radio - Android
 Radios allow users to select a single option from a list.
 
 <ComponentsStatus />

--- a/docs/components/radio/frameworks/elements.md
+++ b/docs/components/radio/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Radio - Frameworks
+# Radio - Elements
 Radios allow users to select a single option from a list of choices.
 
 <ComponentsStatus />

--- a/docs/components/radio/frameworks/ios.md
+++ b/docs/components/radio/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Radio - Frameworks
+# Radio - iOS
 Radios allow users to select a single option from a list.
 
 <ComponentsStatus />

--- a/docs/components/radio/frameworks/react.md
+++ b/docs/components/radio/frameworks/react.md
@@ -1,4 +1,4 @@
-# Radio - Frameworks
+# Radio - React
 Radios allow users to select a single option from a list.
 
 <ComponentsStatus />

--- a/docs/components/radio/frameworks/vue.md
+++ b/docs/components/radio/frameworks/vue.md
@@ -1,4 +1,4 @@
-# Radio - Frameworks
+# Radio - Vue
 Radios allow users to select a single option from a list.
 
 <ComponentsStatus />

--- a/docs/components/range-slider/frameworks/android.md
+++ b/docs/components/range-slider/frameworks/android.md
@@ -1,4 +1,4 @@
-# Range slider - Frameworks
+# Range slider - Android
 
 Range sliders are best suited for cases where people need to quickly set a value within a designated range. They offer an intuitive way to adjust settings like volume, price filters, or relative distances.
 

--- a/docs/components/range-slider/frameworks/elements.md
+++ b/docs/components/range-slider/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Range slider - Frameworks
+# Range slider - Elements
 
 Range sliders are best suited for cases where people need to quickly set a value within a designated range. They offer an intuitive way to adjust settings like volume, price filters, or relative distances.
 

--- a/docs/components/range-slider/frameworks/ios.md
+++ b/docs/components/range-slider/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Range slider - Frameworks
+# Range slider - iOS
 
 Range sliders are best suited for cases where people need to quickly set a value within a designated range. They offer an intuitive way to adjust settings like volume, price filters, or relative distances.
 

--- a/docs/components/range-slider/frameworks/react-19.md
+++ b/docs/components/range-slider/frameworks/react-19.md
@@ -1,4 +1,4 @@
-# Range slider - Frameworks
+# Range slider - React 19
 
 Range sliders are best suited for cases where people need to quickly set a value within a designated range. They offer an intuitive way to adjust settings like volume, price filters, or relative distances.
 

--- a/docs/components/select/frameworks/android.md
+++ b/docs/components/select/frameworks/android.md
@@ -1,4 +1,4 @@
-# Select - Frameworks
+# Select - Android
 A select is a form input component that lets users choose one option from a predefined list.
 
 <ComponentsStatus />

--- a/docs/components/select/frameworks/elements.md
+++ b/docs/components/select/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Select - Frameworks
+# Select - Elements
 A select is a form input component that lets users choose one option from a predefined list.
 
 <ComponentsStatus />

--- a/docs/components/select/frameworks/ios.md
+++ b/docs/components/select/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Select - Frameworks
+# Select - iOS
 A select is a form input component that lets users choose one option from a predefined list.
 
 <ComponentsStatus />

--- a/docs/components/select/frameworks/react.md
+++ b/docs/components/select/frameworks/react.md
@@ -1,4 +1,4 @@
-# Select - Frameworks
+# Select - React
 A select is a form input component that lets users choose one option from a predefined list.
 
 <ComponentsStatus />

--- a/docs/components/select/frameworks/vue.md
+++ b/docs/components/select/frameworks/vue.md
@@ -1,4 +1,4 @@
-# Select - Frameworks
+# Select - Vue
 A select is a form input component that lets users choose one option from a predefined list.
 
 <ComponentsStatus />

--- a/docs/components/slider/frameworks/android.md
+++ b/docs/components/slider/frameworks/android.md
@@ -1,4 +1,4 @@
-# Slider - Frameworks
+# Slider - Android
 
 Sliders are best suited for cases where people need to quickly set a value within a designated range. They offer an intuitive way to adjust settings like volume, price filters, or relative distances.
 

--- a/docs/components/slider/frameworks/elements.md
+++ b/docs/components/slider/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Slider - Frameworks
+# Slider - Elements
 
 Sliders are best suited for cases where people need to quickly set a value within a designated range. They offer an intuitive way to adjust settings like volume, price filters, or relative distances.
 

--- a/docs/components/slider/frameworks/ios.md
+++ b/docs/components/slider/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Slider - Frameworks
+# Slider - iOS
 
 Sliders are best suited for cases where people need to quickly set a value within a designated range. They offer an intuitive way to adjust settings like volume, price filters, or relative distances.
 

--- a/docs/components/slider/frameworks/react-19.md
+++ b/docs/components/slider/frameworks/react-19.md
@@ -1,4 +1,4 @@
-# Slider - Frameworks
+# Slider - React 19
 
 Sliders are best suited for cases where people need to quickly set a value within a designated range. They offer an intuitive way to adjust settings like volume, price filters, or relative distances.
 

--- a/docs/components/slider/frameworks/react.md
+++ b/docs/components/slider/frameworks/react.md
@@ -1,4 +1,4 @@
-# Slider - Frameworks
+# Slider - React
 
 Sliders are best suited for cases where people need to quickly set a value within a designated range. They offer an intuitive way to adjust settings like volume, price filters, or relative distances.
 

--- a/docs/components/slider/frameworks/vue.md
+++ b/docs/components/slider/frameworks/vue.md
@@ -1,4 +1,4 @@
-# Slider - Frameworks
+# Slider - Vue
 
 Sliders are best suited for cases where people need to quickly set a value within a designated range. They offer an intuitive way to adjust settings like volume, price filters, or relative distances.
 

--- a/docs/components/spinner/frameworks/android.md
+++ b/docs/components/spinner/frameworks/android.md
@@ -1,4 +1,4 @@
-# Spinner - Frameworks
+# Spinner - Android
 A spinner informs users about the loading of content.
 
 <ComponentsStatus />

--- a/docs/components/spinner/frameworks/ios.md
+++ b/docs/components/spinner/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Spinner - Frameworks
+# Spinner - iOS
 A spinner informs users about the loading of content.
 
 <ComponentsStatus />

--- a/docs/components/steps/frameworks/android.md
+++ b/docs/components/steps/frameworks/android.md
@@ -1,4 +1,4 @@
-# Steps - Frameworks
+# Steps - Android
 The steps component is built to handle user journeys, showing progress.
 
 <ComponentsStatus />

--- a/docs/components/steps/frameworks/elements.md
+++ b/docs/components/steps/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Steps - Frameworks
+# Steps - Elements
 The steps component is built to handle user journeys, showing progress.
 
 <ComponentsStatus />

--- a/docs/components/steps/frameworks/ios.md
+++ b/docs/components/steps/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Steps - Frameworks
+# Steps - iOS
 The steps component is built to handle user journeys, showing progress.
 
 <ComponentsStatus />

--- a/docs/components/steps/frameworks/react.md
+++ b/docs/components/steps/frameworks/react.md
@@ -1,4 +1,4 @@
-# Steps - Frameworks
+# Steps - React
 The steps component is built to handle user journeys, showing progress.
 
 <ComponentsStatus />

--- a/docs/components/steps/frameworks/vue.md
+++ b/docs/components/steps/frameworks/vue.md
@@ -1,4 +1,4 @@
-# Steps - Frameworks
+# Steps - Vue
 The steps component is built to handle user journeys, showing progress.
 
 <ComponentsStatus />

--- a/docs/components/tabs/frameworks/android.md
+++ b/docs/components/tabs/frameworks/android.md
@@ -1,4 +1,4 @@
-# Tabs - Frameworks
+# Tabs - Android
 Tabs are used to group content, allowing users to navigate views without.
 
 <ComponentsStatus />

--- a/docs/components/tabs/frameworks/elements.md
+++ b/docs/components/tabs/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Tabs - Frameworks
+# Tabs - Elements
 Tabs are used to group content, allowing users to navigate views without leaving the page.
 
 <ComponentsStatus />

--- a/docs/components/tabs/frameworks/ios.md
+++ b/docs/components/tabs/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Tabs - Frameworks
+# Tabs - iOS
 Tabs are used to group content, allowing users to navigate views without.
 
 <ComponentsStatus />

--- a/docs/components/tabs/frameworks/react.md
+++ b/docs/components/tabs/frameworks/react.md
@@ -1,4 +1,4 @@
-# Tabs - Frameworks
+# Tabs - React
 Tabs are used to group content, allowing users to navigate views without.
 
 <ComponentsStatus />

--- a/docs/components/tabs/frameworks/vue.md
+++ b/docs/components/tabs/frameworks/vue.md
@@ -1,4 +1,4 @@
-# Tabs - Frameworks
+# Tabs - Vue
 Tabs are used to group content, allowing users to navigate views without.
 
 <ComponentsStatus />

--- a/docs/components/text-area/frameworks/elements.md
+++ b/docs/components/text-area/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Text area - Frameworks
+# Text area - Elements
 A text area allows users to input extended text content that covers multiple lines.
 
 <ComponentsStatus />

--- a/docs/components/text-area/frameworks/ios.md
+++ b/docs/components/text-area/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Text area - Frameworks
+# Text area - iOS
 A text area allows users to input extended text content that covers multiple lines.
 
 <ComponentsStatus />

--- a/docs/components/text-area/frameworks/react.md
+++ b/docs/components/text-area/frameworks/react.md
@@ -1,4 +1,4 @@
-# Text area - Frameworks
+# Text area - React
 A text area allows users to input extended text content that covers multiple lines.
 
 <ComponentsStatus />

--- a/docs/components/text-area/frameworks/vue.md
+++ b/docs/components/text-area/frameworks/vue.md
@@ -1,4 +1,4 @@
-# Text area - Frameworks
+# Text area - Vue
 A text area allows users to input extended text content that covers multiple lines.
 
 <ComponentsStatus />

--- a/docs/components/text-field/frameworks/android.md
+++ b/docs/components/text-field/frameworks/android.md
@@ -1,4 +1,4 @@
-# Text field - Frameworks
+# Text field - Android
 A text field is a single-line input component used for entering and editing textual data.
 
 <ComponentsStatus />

--- a/docs/components/text-field/frameworks/elements.md
+++ b/docs/components/text-field/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Text field - Frameworks
+# Text field - Elements
 A text field is a single-line input component used for entering and editing textual data.
 
 <ComponentsStatus />

--- a/docs/components/text-field/frameworks/ios.md
+++ b/docs/components/text-field/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Text field - Frameworks
+# Text field - iOS
 A text field is a single-line input component used for entering and editing textual data.
 
 <ComponentsStatus />

--- a/docs/components/text-field/frameworks/react.md
+++ b/docs/components/text-field/frameworks/react.md
@@ -1,4 +1,4 @@
-# Text field - Frameworks
+# Text field - React
 A text field is a single-line input component used for entering and editing textual data.
 
 <ComponentsStatus />

--- a/docs/components/text-field/frameworks/vue.md
+++ b/docs/components/text-field/frameworks/vue.md
@@ -1,4 +1,4 @@
-# Text field - Frameworks
+# Text field - Vue
 A text field is a single-line input component used for entering and editing textual data.
 
 <ComponentsStatus />

--- a/docs/components/text/frameworks/android.md
+++ b/docs/components/text/frameworks/android.md
@@ -1,4 +1,4 @@
-# Text - Frameworks
+# Text - Android
 Pre-defined styles provide a font and size.
 
 <ComponentsStatus />

--- a/docs/components/text/frameworks/ios.md
+++ b/docs/components/text/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Text - Frameworks
+# Text - iOS
 Pre-defined styles provide a font and size.
 
 <ComponentsStatus />

--- a/docs/components/toast/frameworks/android.md
+++ b/docs/components/toast/frameworks/android.md
@@ -1,4 +1,4 @@
-# Toast - Frameworks
+# Toast - Android
 Toasts are brief user feedback messages that overlay content.
 
 <ComponentsStatus />

--- a/docs/components/toast/frameworks/elements.md
+++ b/docs/components/toast/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Toast - Frameworks
+# Toast - Elements
 Toasts are brief user feedback messages that overlay content.
 
 <ComponentsStatus />

--- a/docs/components/toast/frameworks/ios.md
+++ b/docs/components/toast/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Toast - Frameworks
+# Toast - iOS
 Toasts are brief user feedback messages that overlay content.
 
 <ComponentsStatus />

--- a/docs/components/toast/frameworks/react-19.md
+++ b/docs/components/toast/frameworks/react-19.md
@@ -1,4 +1,4 @@
-# Toast - Frameworks
+# Toast - React 19
 Toasts are brief user feedback messages that overlay content.
 
 <ComponentsStatus />

--- a/docs/components/tooltip/frameworks/android.md
+++ b/docs/components/tooltip/frameworks/android.md
@@ -1,4 +1,4 @@
-# Tooltip - Frameworks
+# Tooltip - Android
 A tooltip is a message box that is displayed when a user hovers over or gives focus to a UI element.
 
 <ComponentsStatus />

--- a/docs/components/tooltip/frameworks/elements.md
+++ b/docs/components/tooltip/frameworks/elements.md
@@ -1,4 +1,4 @@
-# Tooltip - Frameworks
+# Tooltip - Elements
 A tooltip is a message box that is displayed when a user hovers over or gives focus to a UI element.
 
 <ComponentsStatus />

--- a/docs/components/tooltip/frameworks/ios.md
+++ b/docs/components/tooltip/frameworks/ios.md
@@ -1,4 +1,4 @@
-# Tooltip - Frameworks
+# Tooltip - iOS
 A tooltip is a message box that is displayed when a user hovers over or gives focus to a UI element.
 
 <ComponentsStatus />

--- a/docs/components/tooltip/frameworks/react.md
+++ b/docs/components/tooltip/frameworks/react.md
@@ -1,4 +1,4 @@
-# Tooltip - Frameworks
+# Tooltip - React
 A tooltip is a message box that is displayed when a user hovers over or gives focus to a UI element.
 
 <ComponentsStatus />

--- a/docs/components/tooltip/frameworks/vue.md
+++ b/docs/components/tooltip/frameworks/vue.md
@@ -1,4 +1,4 @@
-# Tooltip - Frameworks
+# Tooltip - Vue
 A tooltip is a message box that is displayed when a user hovers over or gives focus to a UI element.
 
 <ComponentsStatus />

--- a/docs/components/utilities/frameworks/vue.md
+++ b/docs/components/utilities/frameworks/vue.md
@@ -1,4 +1,4 @@
-# Utilities - Frameworks
+# Utilities - Vue
 These utility components are available to make some layout components interactive.
 
 <ComponentsStatus />

--- a/scripts/frameworks-title-touchup.js
+++ b/scripts/frameworks-title-touchup.js
@@ -33,10 +33,10 @@ function scanFrameworks(globPattern, ignore, nameIndex) {
     const itemName = parts[nameIndex];
     const frameworkFile = basename(file, '.md');
 
-    const displayName =  toDisplayName(frameworkFile);
-    const content = readFileSync(file, "utf-8");
-    const newContent = content.replace(" - Frameworks", ` - ${displayName}`);
-    writeFileSync(file, newContent, "utf-8");
+    const displayName = toDisplayName(frameworkFile);
+    const content = readFileSync(file, 'utf-8');
+    const newContent = content.replace(' - Frameworks', ` - ${displayName}`);
+    writeFileSync(file, newContent, 'utf-8');
   }
 }
 

--- a/scripts/frameworks-title-touchup.js
+++ b/scripts/frameworks-title-touchup.js
@@ -1,0 +1,47 @@
+import { globSync, readFileSync, writeFileSync } from 'node:fs';
+import { basename } from 'node:path';
+
+// Special case display names
+const specialNames = {
+  ios: 'iOS',
+};
+
+/**
+ * Convert filename to display name
+ * Examples: 'vue' -> 'Vue', 'react-19' -> 'React 19', 'ios' -> 'iOS'
+ */
+function toDisplayName(filename) {
+  if (specialNames[filename]) {
+    return specialNames[filename];
+  }
+  return filename
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+/**
+ * @param {string} globPattern - Glob pattern to match framework files
+ * @param {string[]} ignore - Patterns to ignore
+ * @param {number} nameIndex - Index of the item name in the path parts
+ * @returns {Object} Sorted manifest section
+ */
+function scanFrameworks(globPattern, ignore, nameIndex) {
+  const files = globSync(globPattern, { ignore });
+  for (const file of files) {
+    const parts = file.split('/');
+    const itemName = parts[nameIndex];
+    const frameworkFile = basename(file, '.md');
+
+    const displayName =  toDisplayName(frameworkFile);
+    const content = readFileSync(file, "utf-8");
+    const newContent = content.replace(" - Frameworks", ` - ${displayName}`);
+    writeFileSync(file, newContent, "utf-8");
+  }
+}
+
+scanFrameworks(
+  'docs/components/*/frameworks/*.md',
+  ['docs/components/.template/**'],
+  2, // 'docs/components/alert/frameworks/vue.md' -> index 2 is 'alert'
+);


### PR DESCRIPTION
Got distracted, I think these changes are necessary for search and navigation. Compare the before and after for search for example, you'd get up to five hits for "Box - Framework". Which one of those is the one I'm after? By changing the title to include the actual framework name it's much easier to see which hit is most relevant for me.

<img width="897" height="669" alt="before, five hits for box - framework" src="https://github.com/user-attachments/assets/ef7faecf-7a9e-4319-b789-5ae1fbf1b887" />

<img width="897" height="668" alt="after, five hits for box but all with different framework names (react, ios, android, elements, vue)" src="https://github.com/user-attachments/assets/e4e08b76-820d-4b87-a1d5-94dc6c03b63a" />

<img width="897" height="669" alt="sidebar with all framework pages listed under a non-clickable Frameworks heading" src="https://github.com/user-attachments/assets/a02221f7-e120-403a-8477-e651723ec7aa" />

